### PR TITLE
MNT(actions): fix tests

### DIFF
--- a/.github/actions/test/action.yaml
+++ b/.github/actions/test/action.yaml
@@ -30,5 +30,5 @@ runs:
         pip install "torch==${PYTORCH_VERSION}" pytest
         [ "${PYTORCH_VERSION}" == "1.4" ] && pip install numpy
         pip install .
-        pytest pytest --pyargs jitfields
+        pytest pytest --pyargs jitfields --maxfail=1
       shell: bash

--- a/.github/actions/test/action.yaml
+++ b/.github/actions/test/action.yaml
@@ -37,8 +37,8 @@ runs:
         mamba install pytorch=${PYTORCH_VERSION} cppyy numpy pytest
     - name: Test with pytest
       shell: bash -el {0}
-      env: 
-        EXTRA_CLING_ARGS: -DJF_USE_SEQ
+      # env: 
+      #   EXTRA_CLING_ARGS: -DJF_USE_SEQ
       run: |
         pip install .
         pytest pytest --pyargs jitfields --maxfail=1

--- a/.github/actions/test/action.yaml
+++ b/.github/actions/test/action.yaml
@@ -16,22 +16,23 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: mamba-org/setup-micromamba@v1
-      with:
-        environment-name: test-env
-        create-args: >-
-          -c conda-forge
-          -c pytorch 
-          python=${{ inputs.python-version }}
-          pytorch=${{ inputs.pytorch-version }}
-          cppyy
-          numpy
-          pytest
     - uses: actions/checkout@v3
       with:
         ref: ${{ inputs.tag }}
+    - uses: conda-incubator/setup-miniconda@v2
+      with:
+        mamba-version: "*"
+        python-version: ${{ inputs.python-version }}
+        channels: conda-forge,pytorch,defaults
+        activate-environment: test-env
+    - name: Install dependencies
+      shell: bash -el {0}
+      env: 
+        PYTORCH_VERSION: ${{ inputs.pytorch-version }}
+      run: |
+        mamba install pytorch=${PYTORCH_VERSION} cppyy numpy pytest
     - name: Test with pytest
+      shell: bash -el {0}
       run: |
         pip install .
         pytest pytest --pyargs jitfields --maxfail=1
-      shell: micromamba-shell {0}

--- a/.github/actions/test/action.yaml
+++ b/.github/actions/test/action.yaml
@@ -25,6 +25,10 @@ runs:
         python-version: ${{ inputs.python-version }}
         channels: conda-forge,pytorch,defaults
         activate-environment: test-env
+    - name: Install libomp
+      shell: bash -el {0}
+      run: |
+        sudo apt update && sudo apt upgrade && sudo apt install libomp-dev
     - name: Install dependencies
       shell: bash -el {0}
       env: 

--- a/.github/actions/test/action.yaml
+++ b/.github/actions/test/action.yaml
@@ -25,10 +25,6 @@ runs:
         python-version: ${{ inputs.python-version }}
         channels: conda-forge,pytorch,defaults
         activate-environment: test-env
-    - name: Install libomp
-      shell: bash -el {0}
-      run: |
-        sudo apt update && sudo apt upgrade && sudo apt install libomp-dev
     - name: Install dependencies
       shell: bash -el {0}
       env: 
@@ -37,8 +33,8 @@ runs:
         mamba install pytorch=${PYTORCH_VERSION} cppyy numpy pytest
     - name: Test with pytest
       shell: bash -el {0}
-      # env: 
-      #   EXTRA_CLING_ARGS: -DJF_USE_SEQ
+      env: 
+        EXTRA_CLING_ARGS: -DJF_USE_SEQ
       run: |
         pip install .
         pytest pytest --pyargs jitfields --maxfail=1

--- a/.github/actions/test/action.yaml
+++ b/.github/actions/test/action.yaml
@@ -16,19 +16,22 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - uses: mamba-org/setup-micromamba@v1
+      with:
+        environment-name: test-env
+        create-args: >-
+          -c conda-forge
+          -c pytorch 
+          python=${{ inputs.python-version }}
+          pytorch=${{ inputs.pytorch-version }}
+          cppyy
+          numpy
+          pytest
     - uses: actions/checkout@v3
       with:
         ref: ${{ inputs.tag }}
-    - name: Setup Python ${{ inputs.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ inputs.python-version }}
     - name: Test with pytest
-      env:
-        PYTORCH_VERSION: ${{ inputs.pytorch-version }}
       run: |
-        pip install "torch==${PYTORCH_VERSION}" pytest
-        [ "${PYTORCH_VERSION}" == "1.4" ] && pip install numpy
         pip install .
         pytest pytest --pyargs jitfields --maxfail=1
-      shell: bash
+      shell: micromamba-shell {0}

--- a/.github/actions/test/action.yaml
+++ b/.github/actions/test/action.yaml
@@ -33,6 +33,8 @@ runs:
         mamba install pytorch=${PYTORCH_VERSION} cppyy numpy pytest
     - name: Test with pytest
       shell: bash -el {0}
+      env: 
+        EXTRA_CLING_ARGS: -DJF_USE_SEQ
       run: |
         pip install .
         pytest pytest --pyargs jitfields --maxfail=1

--- a/OTHER_LICENSES
+++ b/OTHER_LICENSES
@@ -1,0 +1,144 @@
+# ======================================================================
+# Routines for parallel processing (parallel_for, atomic operations)
+# were adapted from PyTorch's ATen library.
+# PyTorch is released under the BSD-3 license, which is compatible with 
+# the MIT license.
+# ======================================================================
+
+From PyTorch:
+
+Copyright (c) 2016-     Facebook, Inc            (Adam Paszke)
+Copyright (c) 2014-     Facebook, Inc            (Soumith Chintala)
+Copyright (c) 2011-2014 Idiap Research Institute (Ronan Collobert)
+Copyright (c) 2012-2014 Deepmind Technologies    (Koray Kavukcuoglu)
+Copyright (c) 2011-2012 NEC Laboratories America (Koray Kavukcuoglu)
+Copyright (c) 2011-2013 NYU                      (Clement Farabet)
+Copyright (c) 2006-2010 NEC Laboratories America (Ronan Collobert, Leon Bottou, Iain Melvin, Jason Weston)
+Copyright (c) 2006      Idiap Research Institute (Samy Bengio)
+Copyright (c) 2001-2004 Idiap Research Institute (Ronan Collobert, Samy Bengio, Johnny Mariethoz)
+
+From Caffe2:
+
+Copyright (c) 2016-present, Facebook Inc. All rights reserved.
+
+All contributions by Facebook:
+Copyright (c) 2016 Facebook Inc.
+
+All contributions by Google:
+Copyright (c) 2015 Google Inc.
+All rights reserved.
+
+All contributions by Yangqing Jia:
+Copyright (c) 2015 Yangqing Jia
+All rights reserved.
+
+All contributions by Kakao Brain:
+Copyright 2019-2020 Kakao Brain
+
+All contributions by Cruise LLC:
+Copyright (c) 2022 Cruise LLC.
+All rights reserved.
+
+All contributions from Caffe:
+Copyright(c) 2013, 2014, 2015, the respective contributors
+All rights reserved.
+
+All other contributions:
+Copyright(c) 2015, 2016 the respective contributors
+All rights reserved.
+
+Caffe2 uses a copyright model similar to Caffe: each contributor holds
+copyright over their contributions to Caffe2. The project versioning records
+all such contribution and copyright details. If a contributor wants to further
+mark their specific copyright on a particular contribution, they should
+indicate their copyright solely in the commit message of the change when it is
+committed.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+3. Neither the names of Facebook, Deepmind Technologies, NYU, NEC Laboratories America
+   and IDIAP Research Institute nor the names of its contributors may be
+   used to endorse or promote products derived from this software without
+   specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+# ======================================================================
+# The native threadpool implementation was copied and adapted from
+# https://github.com/YasserAsmi/wstpool
+# which is released under the MIT license.
+# ======================================================================
+
+From wstpool:
+
+MIT License
+
+Copyright (c) 2021 Yasser Asmi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+# ======================================================================
+# The mesh distance was adapted from
+# https://github.com/InteractiveComputerGraphics/TriangleMeshDistance
+# which is released under the MIT license.
+# ======================================================================
+
+From TriangleMeshDistance:
+
+MIT License
+
+Copyright (c) 2021 Jose Antonio Fernandez Fernandez
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/jitfields/bindings/cpp/__init__.py
+++ b/jitfields/bindings/cpp/__init__.py
@@ -6,4 +6,6 @@ import torch as _
 # I also turn on O3 optimization (at the cost of compilation speed and bytecode size)
 # O3 enables various loop optimizations (unrolling, splitting, peeling, ...)
 import os
-os.environ['EXTRA_CLING_ARGS'] = '-fopenmp -O3'
+EXTRA_CLING_ARGS = os.environ.get('EXTRA_CLING_ARGS', '')
+EXTRA_CLING_ARGS = '-fopenmp -O3 ' + EXTRA_CLING_ARGS
+os.environ['EXTRA_CLING_ARGS'] = EXTRA_CLING_ARGS

--- a/jitfields/bindings/cpp/__init__.py
+++ b/jitfields/bindings/cpp/__init__.py
@@ -6,4 +6,4 @@ import torch as _
 # I also turn on O3 optimization (at the cost of compilation speed and bytecode size)
 # O3 enables various loop optimizations (unrolling, splitting, peeling, ...)
 import os
-os.environ['EXTRA_CLING_ARGS'] = '-fopenmp=libomp -O3'
+os.environ['EXTRA_CLING_ARGS'] = '-fopenmp -O3'

--- a/jitfields/bindings/cpp/__init__.py
+++ b/jitfields/bindings/cpp/__init__.py
@@ -6,4 +6,4 @@ import torch as _
 # I also turn on O3 optimization (at the cost of compilation speed and bytecode size)
 # O3 enables various loop optimizations (unrolling, splitting, peeling, ...)
 import os
-os.environ['EXTRA_CLING_ARGS'] = '-fopenmp -O3'
+os.environ['EXTRA_CLING_ARGS'] = '-fopenmp=libomp -O3'

--- a/jitfields/csrc/lib/parallel_impl.h
+++ b/jitfields/csrc/lib/parallel_impl.h
@@ -37,7 +37,14 @@
 #define JF_CAN_USE_OPENMP 0
 #endif
 
-#if JF_CAN_USE_OPENMP
+#if JF_CAN_USE_FUTURE
+#include "threadpool.h"
+namespace jf {
+inline size_t get_parallel_threads() { return get_num_threads(); }
+inline size_t set_parallel_threads(int nthreads) { return set_num_threads(nthreads); }
+inline std::string get_parallel_backend() { return "native"; }
+}
+#elif JF_CAN_USE_OPENMP
 #pragma cling load("libomp").
 #include <omp.h>
 namespace jf {
@@ -49,14 +56,6 @@ inline size_t set_parallel_threads(int nthreads)
 }
 inline std::string get_parallel_backend() { return "omp"; }
 }
-#elif JF_CAN_USE_FUTURE
-#include "threadpool.h"
-namespace jf {
-inline size_t get_parallel_threads() { return get_num_threads(); }
-inline size_t set_parallel_threads(int nthreads) { return set_num_threads(nthreads); }
-inline std::string get_parallel_backend() { return "native"; }
-}
-
 #else
 namespace jf {
 inline size_t get_parallel_threads() { return 1; }

--- a/jitfields/csrc/lib/parallel_impl.h
+++ b/jitfields/csrc/lib/parallel_impl.h
@@ -23,18 +23,31 @@
  * the thread id in our loops (no use for get_thread_num).
  */
 
-#define JF_CAN_USE_FUTURE 1
-#if __clang__
-#if __clang_major__ < 13
-#undef  JF_CAN_USE_FUTURE
-#define JF_CAN_USE_FUTURE 0
-#endif
-#endif
-
-#ifdef _OPENMP
-#define JF_CAN_USE_OPENMP 1
+#ifdef JF_USE_SEQ
+#   define JF_CAN_USE_FUTURE 0
+#   define JF_CAN_USE_OPENMP 0
 #else
-#define JF_CAN_USE_OPENMP 0
+#ifdef JF_USE_FUTURE
+#   define JF_CAN_USE_FUTURE 1
+#   define JF_CAN_USE_OPENMP 0
+#else
+#ifdef JF_USE_OPENMP
+#   define JF_CAN_USE_FUTURE 0
+#   define JF_CAN_USE_OPENMP 1
+#else
+#   define JF_CAN_USE_FUTURE 1
+#   if __clang__
+#   if __clang_major__ < 13
+#   undef  JF_CAN_USE_FUTURE
+#   define JF_CAN_USE_FUTURE 0
+#   endif
+#   endif
+
+#   ifdef _OPENMP
+#   define JF_CAN_USE_OPENMP 1
+#   else
+#   define JF_CAN_USE_OPENMP 0
+#   endif
 #endif
 
 #if JF_CAN_USE_FUTURE

--- a/jitfields/csrc/lib/parallel_impl.h
+++ b/jitfields/csrc/lib/parallel_impl.h
@@ -24,15 +24,19 @@
  */
 
 #ifdef JF_USE_SEQ
+#   undef  JF_CAN_USE_FUTURE
 #   define JF_CAN_USE_FUTURE 0
+#   undef  JF_CAN_USE_OPENMP
 #   define JF_CAN_USE_OPENMP 0
-#else
-#ifdef JF_USE_FUTURE
+#elif defined(JF_USE_FUTURE)
+#   undef  JF_CAN_USE_FUTURE
 #   define JF_CAN_USE_FUTURE 1
+#   undef  JF_CAN_USE_OPENMP
 #   define JF_CAN_USE_OPENMP 0
-#else
-#ifdef JF_USE_OPENMP
+#elif defined(JF_USE_OPENMP)
+#   undef  JF_CAN_USE_FUTURE
 #   define JF_CAN_USE_FUTURE 0
+#   undef  JF_CAN_USE_OPENMP
 #   define JF_CAN_USE_OPENMP 1
 #else
 #   define JF_CAN_USE_FUTURE 1

--- a/jitfields/tests/test_distance.py
+++ b/jitfields/tests/test_distance.py
@@ -1,3 +1,6 @@
+import cppyy
+cppyy.set_debug(True)
+
 from jitfields.distance import (
     l1_distance_transform,
     euclidean_distance_transform

--- a/jitfields/tests/test_distance.py
+++ b/jitfields/tests/test_distance.py
@@ -1,7 +1,6 @@
 import cppyy
 cppyy.set_debug(True)
 from jitfields import get_parallel_backend
-print(get_parallel_backend())
 
 from jitfields.distance import (
     l1_distance_transform,
@@ -17,6 +16,7 @@ devices = get_test_devices()
 @pytest.mark.parametrize("device", devices)
 def test_l1(device):
     device = init_device(device)
+    print(get_parallel_backend())
 
     mask = [[1, 1, 1, 1, 1, 1],
             [1, 1, 1, 1, 1, 1],
@@ -41,6 +41,7 @@ def test_l1(device):
 @pytest.mark.parametrize("device", devices)
 def test_l2(device):
     device = init_device(device)
+    print(get_parallel_backend())
 
     mask = [[1, 1, 1, 1, 1, 1],
             [1, 1, 1, 1, 1, 1],

--- a/jitfields/tests/test_distance.py
+++ b/jitfields/tests/test_distance.py
@@ -1,5 +1,7 @@
 import cppyy
 cppyy.set_debug(True)
+from jitfields import get_parallel_backend
+print(get_parallel_backend())
 
 from jitfields.distance import (
     l1_distance_transform,


### PR DESCRIPTION
I did not manage to get the openmp backend to work (at least not in a github action). llvm complains on `pragma cling load("libomp")`. I've added the possibility to force the use of the sequential backend, which is the backend that is used in the actions for now.